### PR TITLE
Remove husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-cd ./tools
-npm run lint:md
-npm run format 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-cd ./tools
-npm run compile 

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -15,7 +15,6 @@
         "@types/prettier": "^2.7.3",
         "fp-ts": "^2.16.0",
         "fs-extra": "^11.1.1",
-        "husky": "^8.0.3",
         "markdownlint-cli": "^0.35.0",
         "marked": "^5.1.0",
         "prettier": "^3.0.3",
@@ -384,21 +383,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
     },
     "node_modules/ignore": {
       "version": "5.2.4",

--- a/tools/package.json
+++ b/tools/package.json
@@ -7,9 +7,8 @@
     "format": "ts-node format",
     "compile": "ts-node compile",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "cd .. && husky install .husky",
     "lint": "ts-node lint",
-    "lint:md": "markdownlint \".\/*.md\" markdownlint \"..\/*.md\"",
+    "lint:md": "markdownlint \"./*.md\" markdownlint \"../*.md\"",
     "check": "npm run lint:md && npm run format && npm run compile"
   },
   "author": "",
@@ -21,7 +20,6 @@
     "@types/prettier": "^2.7.3",
     "fp-ts": "^2.16.0",
     "fs-extra": "^11.1.1",
-    "husky": "^8.0.3",
     "markdownlint-cli": "^0.35.0",
     "marked": "^5.1.0",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Remove husky, as it is too slow to execute all TS checking on the snippets for every commit.