### PR TITLE
Add lightweight Playwright website E2E tests

### DIFF
--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: website

--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -1,0 +1,113 @@
+name: website-e2e
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  test:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Build website
+        run: npm run build
+      - name: Run core end-to-end tests
+        run: npm run e2e
+      - name: Upload Playwright evidence
+        if: always()
+        id: evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-evidence-pr-${{ github.event.pull_request.number }}
+          path: |
+            website/playwright-report
+            website/test-results
+          if-no-files-found: error
+          retention-days: 14
+      - name: Add evidence to pull request
+        if: always() && steps.evidence.outputs.artifact-url != ''
+        uses: actions/github-script@v8
+        env:
+          ARTIFACT_URL: ${{ steps.evidence.outputs.artifact-url }}
+          TEST_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const marker = '<!-- website-e2e-evidence -->';
+            const status = process.env.TEST_STATUS === 'success' ? '✅ Passed' : '❌ Failed';
+            const body = `${marker}
+            ## Website end-to-end evidence
+
+            **Status:** ${status}
+
+            [Download the Playwright HTML report, screenshots, and videos](${process.env.ARTIFACT_URL})
+
+            This comment is updated by each run. The uploaded evidence is deleted when the pull request is merged.`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const previous = comments.find(comment => comment.body?.includes(marker));
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete merged pull request evidence
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifactName = `playwright-evidence-pr-${context.issue.number}`;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+
+            for (const artifact of artifacts.filter(({ name }) => name === artifactName)) {
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+              });
+            }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -13,6 +13,9 @@ website-deploy:
 website-preview:
 	cd ../website && npm run build && npm run preview
 
+website-e2e:
+	cd ../website && npm run build && npm run e2e
+
 books:
 	./make-books.sh
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,8 +27,30 @@ Use `make` to run the main commands:
 * `make check`: Run several checks to ensure the Markdown files are valid.
 * `make website`: Create different Markdown pages for the website.
 * `make website-preview`: Build and preview website locally.
+* `make website-e2e`: Build the production website and run its core Playwright end-to-end tests.
 * `make website-deploy`: Build and deploy website to GitHub Pages.
 * `make books`: Create .epub books.
+
+### Website End-to-End Tests
+
+The Playwright suite covers only the website's main reader journeys: loading readable
+book content, using the right-side page navigation, and finding content with search.
+
+Install the browser once from the `website` folder:
+
+```shell
+npx playwright install chromium
+```
+
+Then run the production build and tests from the `tools` folder:
+
+```shell
+make website-e2e
+```
+
+Playwright saves an HTML report, screenshots, and videos for each run. In pull
+requests, CI uploads this evidence, links it from a single updated PR comment, and
+deletes the uploaded artifacts after the PR is merged.
 
 ### Formatting
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -2,6 +2,8 @@
 dist/
 # generated types
 .astro/
+playwright-report/
+test-results/
 
 # dependencies
 node_modules/

--- a/website/e2e/reader.spec.ts
+++ b/website/e2e/reader.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+const gettingStartedPath = 'book/getting-started-with-typescript/';
+
+test.describe('core reader journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(gettingStartedPath);
+  });
+
+  test('renders readable book content', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Getting Started With TypeScript',
+      }),
+    ).toBeVisible();
+
+    const article = page.locator('main[data-pagefind-body]');
+    await expect(article).toContainText(
+      'Visual Studio Code provides excellent support for the TypeScript language',
+    );
+  });
+
+  test('uses the right-side page navigation', async ({ page }) => {
+    const pageNavigation = page
+      .locator('starlight-toc')
+      .getByRole('navigation', { name: 'On this page' });
+
+    await expect(pageNavigation).toBeVisible();
+    await pageNavigation
+      .getByRole('link', { name: 'Configuration', exact: true })
+      .click();
+
+    await expect(page).toHaveURL(/#configuration$/);
+    await expect(
+      page.getByRole('heading', { name: 'Configuration', exact: true }),
+    ).toBeInViewport();
+  });
+
+  test('finds and opens book content with search', async ({ page }) => {
+    const searchButton = page.getByRole('button', { name: 'Search' });
+    await expect(searchButton).toBeEnabled();
+    await searchButton.click();
+
+    const search = page.locator('#starlight__search input');
+    await expect(search).toBeVisible();
+    await search.fill('Discriminated Unions');
+
+    const result = page
+      .locator('#starlight__search')
+      .getByRole('link')
+      .filter({ hasText: 'Discriminated Unions' })
+      .first();
+
+    await expect(result).toBeVisible();
+    await result.click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Discriminated Unions' }),
+    ).toBeVisible();
+  });
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,6 +15,7 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "gh-pages": "^6.1.1"
       }
     },
@@ -1393,9 +1394,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1411,9 +1409,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1431,9 +1426,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1449,9 +1441,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1469,9 +1458,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1488,9 +1474,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1506,9 +1489,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1532,9 +1512,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1556,9 +1533,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1582,9 +1556,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1607,9 +1578,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1631,9 +1599,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1889,6 +1854,22 @@
         "win32"
       ]
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -2014,9 +1995,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2029,9 +2007,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2046,9 +2021,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2061,9 +2033,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2078,9 +2047,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,9 +2059,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2110,9 +2073,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2125,9 +2085,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2142,9 +2099,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,9 +2111,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2174,9 +2125,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2190,9 +2138,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,9 +2150,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6656,6 +6598,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,8 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
+    "e2e": "playwright test",
+    "e2e:report": "playwright show-report",
     "astro": "astro",
     "deploy": "npm run build && npx gh-pages -d dist"
   },
@@ -18,6 +20,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "gh-pages": "^6.1.1"
   }
 }

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = 'http://127.0.0.1:4321/typescript-book/';
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: 'test-results',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'on',
+    video: 'on',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## What changed

This adds a small Playwright end-to-end suite for the Astro/Starlight website. It intentionally covers only the reader journeys that tell us the built site is usable:

- a production page loads and exposes readable book content;
- the right-side **On this page** navigation moves to the selected section;
- search finds a book topic and opens the matching page.

The suite uses one Chromium project and three direct, role-oriented tests. There are no page objects or custom abstractions because the current scope does not justify them.

## How it works

The pull-request workflow installs the locked website dependencies and Chromium, builds the production Astro site, starts the production preview server through Playwright, and runs the tests against the repository's `/typescript-book/` base path.

Screenshots and videos are recorded for every test. The Playwright HTML report and raw test evidence are uploaded even when a test fails. A single bot comment on the PR is created or updated with the latest status and artifact download link.

When the PR is merged, the workflow deletes all Playwright evidence artifacts associated with that PR. GitHub's 14-day retention remains only as a fallback for abandoned or closed-without-merge PRs.

## Developer commands

From `tools/`:

```shell
make website-e2e
```

The tools documentation also explains the one-time local Chromium installation and generated evidence.

## Validation

- `npm run build` — passed with no Astro errors, warnings, or hints
- `npx playwright test --list` — discovered 3 Chromium tests
- The PR workflow performs the full browser execution and publishes its evidence in the PR conversation
