### PR TITLE
Run website e2e for ready pull requests

### DIFF
--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -2,7 +2,7 @@ name: website-e2e
 
 on:
   pull_request:
-    types: [ready_for_review, closed]
+    types: [ready_for_review, synchronize, closed]
 
 permissions:
   actions: write
@@ -12,7 +12,9 @@ permissions:
 
 jobs:
   test:
-    if: github.event.action == 'ready_for_review'
+    if: >-
+      github.event.action == 'ready_for_review' ||
+      (github.event.action == 'synchronize' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -55,13 +57,13 @@ jobs:
             const marker = '<!-- website-e2e-evidence -->';
             const status = process.env.TEST_STATUS === 'success' ? '✅ Passed' : '❌ Failed';
             const body = `${marker}
-            ## Website end-to-end evidence
+            ## Website E2E report
 
             **Status:** ${status}
 
             [Download the Playwright HTML report, screenshots, and videos](${process.env.ARTIFACT_URL})
 
-            This comment is updated by each run. The uploaded evidence is deleted when the pull request is merged.`;
+            This comment is updated when the pull request is marked ready for review and after each new push. The uploaded evidence is deleted when the pull request is merged.`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -2,7 +2,7 @@ name: website-e2e
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [ready_for_review, closed]
 
 permissions:
   actions: write
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    if: github.event.action != 'closed'
+    if: github.event.action == 'ready_for_review'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/website/e2e/reader.spec.ts
+++ b/website/e2e/reader.spec.ts
@@ -5,6 +5,9 @@ const gettingStartedPath = 'book/getting-started-with-typescript/';
 test.describe('core reader journeys', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(gettingStartedPath);
+    await page
+      .getByRole('button', { name: 'Reject non-essential' })
+      .click();
   });
 
   test('renders readable book content', async ({ page }) => {


### PR DESCRIPTION
## What changed

The website Playwright workflow now runs:

- when a pull request is marked **Ready for review**
- again after every new push to a ready, non-draft pull request

Draft pull requests remain excluded. The existing merged-PR cleanup remains enabled.

Each test run uploads the Playwright HTML report, screenshots, videos, traces, and test results. The workflow creates one **Website E2E report** comment on the pull request and updates that same comment after subsequent runs, avoiding duplicate comments.

The reader E2E setup also dismisses the cookie-consent banner through its accessible **Reject non-essential** button before testing content, page navigation, and search.

## Rationale

Playwright builds the full website, installs Chromium, and exercises the core reader journeys. Deferring the first run until the pull request is ready avoids unnecessary CI work while changes are still being drafted.

Once review has started, every synchronized push can change the website or invalidate an earlier result. Rerunning E2E after those pushes keeps the reported result aligned with the current commit.

The right-side navigation test previously timed out because the Silktide cookie banner intercepted pointer events over the navigation link. Explicitly dismissing the banner models a real user action and removes that race without forced clicks, fixed delays, or longer timeouts.

Updating a single report comment keeps the pull-request discussion readable while still making the latest HTML report and evidence easy to find.

## Validation

- Parsed the updated workflow as YAML.
- Verified the event list contains `ready_for_review`, `synchronize`, and `closed`.
- Verified synchronized events run E2E only when `github.event.pull_request.draft == false`.
- Verified the report comment updates with the latest artifact.
- Ran the synchronized GitHub Actions workflow successfully.
- All 3 Playwright tests passed in 8.5 seconds.
- The right-side navigation test passed in 1.5 seconds.

## Expected behavior

- Draft PR opened or updated: Playwright E2E does not run.
- PR marked ready for review: the website is built and Playwright E2E runs.
- New commits pushed to the ready PR: Playwright E2E runs again and updates the report comment.
- Reader tests dismiss the cookie banner before interacting with the page.
- Merged PR closed: existing Playwright evidence cleanup runs.