### PR TITLE
feat: add llms.txt and Markdown documentation endpoints

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import { defaultLocale, locales } from './src/config/locales';
 
 // https://astro.build/config
 export default defineConfig({
@@ -135,37 +136,8 @@ gtag('config', 'G-SR2LV8LB90');
         github: 'https://github.com/gibbok/typescript-book',
         'x.com': 'https://twitter.com/gibbok_coding',
       },
-      defaultLocale: 'root',
-      locales: {
-        root: {
-          label: 'English',
-          lang: 'en',
-        },
-        'zh-cn': {
-          label: '简体中文',
-          lang: 'zh-CN',
-        },
-        'it-it': {
-          label: 'Italiano',
-          lang: 'it-IT',
-        },
-        'pt-br': {
-          label: 'Português (Brasil)',
-          lang: 'pt-BR',
-        },
-        'sv-se': {
-          label: 'Svenska',
-          lang: 'sv-SE',
-        },
-        "bg-bg": {
-          label: "Български",
-          lang: "bg-BG"
-        },
-        'es-es': {
-          label: 'Español',
-          lang: 'es-ES',
-        },
-      },
+      defaultLocale,
+      locales,
       sidebar: [
         {
           label: 'TypeScript Book',

--- a/website/e2e/llms.spec.ts
+++ b/website/e2e/llms.spec.ts
@@ -27,3 +27,10 @@ test('exposes correctly encoded indexes for configured locales', async ({ page }
   await expect(page.locator('body')).toContainText('За автора');
   await expect(page.locator('body')).toContainText('/bg-bg/book/about-the-author/index.md');
 });
+
+test('exposes a correctly encoded Chinese index', async ({ page }) => {
+  await page.goto('zh-cn/llms.txt');
+
+  await expect(page.locator('body')).toContainText('关于作者');
+  await expect(page.locator('body')).toContainText('/zh-cn/book/about-the-author/index.md');
+});

--- a/website/e2e/llms.spec.ts
+++ b/website/e2e/llms.spec.ts
@@ -7,6 +7,9 @@ test('exposes an llms.txt index for the documentation', async ({ page }) => {
   await expect(page.locator('body')).toContainText(
     '[Readonly Properties](https://gibbok.github.io/typescript-book/book/readonly-properties/index.md)',
   );
+  await expect(page.locator('body')).toContainText(
+    '[Table of Contents](https://gibbok.github.io/typescript-book/book/table-of-contents/index.md): Table of Contents',
+  );
 });
 
 test('exposes a documentation page as Markdown', async ({ page }) => {

--- a/website/e2e/llms.spec.ts
+++ b/website/e2e/llms.spec.ts
@@ -17,3 +17,10 @@ test('exposes a documentation page as Markdown', async ({ page }) => {
     'Is it possible to prevent writing to a property by using the modifier',
   );
 });
+
+test('exposes correctly encoded indexes for configured locales', async ({ page }) => {
+  await page.goto('bg-bg/llms.txt');
+
+  await expect(page.locator('body')).toContainText('За автора');
+  await expect(page.locator('body')).toContainText('/bg-bg/book/about-the-author/index.md');
+});

--- a/website/e2e/llms.spec.ts
+++ b/website/e2e/llms.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('exposes an llms.txt index for the documentation', async ({ page }) => {
+  await page.goto('llms.txt');
+
+  await expect(page.locator('body')).toContainText('# TypeScript Book');
+  await expect(page.locator('body')).toContainText(
+    '[Readonly Properties](https://gibbok.github.io/typescript-book/book/readonly-properties/index.md)',
+  );
+});
+
+test('exposes a documentation page as Markdown', async ({ page }) => {
+  const response = await page.goto('book/readonly-properties/index.md');
+
+  expect(response?.headers()['content-type']).toContain('text/markdown');
+  await expect(page.locator('body')).toContainText(
+    'Is it possible to prevent writing to a property by using the modifier',
+  );
+});

--- a/website/e2e/llms.spec.ts
+++ b/website/e2e/llms.spec.ts
@@ -13,11 +13,11 @@ test('exposes an llms.txt index for the documentation', async ({ page }) => {
 });
 
 test('exposes a documentation page as Markdown', async ({ page }) => {
-  const response = await page.goto('book/readonly-properties/index.md');
+  const response = await page.goto('book/type-annotations/index.md');
 
   expect(response?.headers()['content-type']).toContain('text/markdown');
   await expect(page.locator('body')).toContainText(
-    'Is it possible to prevent writing to a property by using the modifier',
+    '# Type Annotations',
   );
 });
 

--- a/website/src/config/locales.ts
+++ b/website/src/config/locales.ts
@@ -1,0 +1,34 @@
+export const defaultLocale = 'root';
+
+export const locales = {
+  root: {
+    label: 'English',
+    lang: 'en',
+  },
+  'zh-cn': {
+    label: '简体中文',
+    lang: 'zh-CN',
+  },
+  'it-it': {
+    label: 'Italiano',
+    lang: 'it-IT',
+  },
+  'pt-br': {
+    label: 'Português (Brasil)',
+    lang: 'pt-BR',
+  },
+  'sv-se': {
+    label: 'Svenska',
+    lang: 'sv-SE',
+  },
+  'bg-bg': {
+    label: 'Български',
+    lang: 'bg-BG',
+  },
+  'es-es': {
+    label: 'Español',
+    lang: 'es-ES',
+  },
+} as const;
+
+export type Locale = keyof typeof locales;

--- a/website/src/lib/llms.ts
+++ b/website/src/lib/llms.ts
@@ -1,0 +1,59 @@
+import type { CollectionEntry } from 'astro:content';
+
+type DocsEntry = CollectionEntry<'docs'>;
+
+const siteBaseUrl = 'https://gibbok.github.io/typescript-book';
+
+const removeMarkdownSyntax = (value: string) =>
+  value
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!?(?:\[[^\]]*\])\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[*_#>[\]{}]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const firstParagraph = (body: string) => {
+  const paragraphs = body.split(/\n\s*\n/);
+
+  return paragraphs
+    .map(removeMarkdownSyntax)
+    .find((paragraph) => paragraph.length > 0) ?? '';
+};
+
+const titleFromId = (id: string) =>
+  id
+    .split('/')
+    .at(-1)!
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+export const getPageTitle = (entry: DocsEntry) =>
+  entry.data.title ?? titleFromId(entry.id);
+
+export const getPageDescription = (entry: DocsEntry) => {
+  const description = entry.data.description ?? firstParagraph(entry.body);
+
+  return removeMarkdownSyntax(description);
+};
+
+const withoutContentExtension = (id: string) =>
+  id
+    .replace(/\.(?:md|mdx)$/, '')
+    .replace(/\/index$/, '')
+    .replace(/^index$/, '');
+
+export const getMarkdownPath = (entry: DocsEntry) =>
+  withoutContentExtension(entry.id)
+    ? `/${withoutContentExtension(entry.id)}/index.md`
+    : '/index.md';
+
+export const getMarkdownUrl = (entry: DocsEntry) =>
+  `${siteBaseUrl}${getMarkdownPath(entry)}`;
+
+export const getPublishedDocs = (entries: DocsEntry[]) =>
+  entries
+    .sort((first, second) => getMarkdownPath(first).localeCompare(getMarkdownPath(second)));

--- a/website/src/lib/llms.ts
+++ b/website/src/lib/llms.ts
@@ -1,8 +1,11 @@
 import type { CollectionEntry } from 'astro:content';
+import { defaultLocale, locales, type Locale } from '../config/locales';
 
 type DocsEntry = CollectionEntry<'docs'>;
 
 const siteBaseUrl = 'https://gibbok.github.io/typescript-book';
+
+export const utf8Bom = '\uFEFF';
 
 const removeMarkdownSyntax = (value: string) =>
   value
@@ -57,3 +60,14 @@ export const getMarkdownUrl = (entry: DocsEntry) =>
 export const getPublishedDocs = (entries: DocsEntry[]) =>
   entries
     .sort((first, second) => getMarkdownPath(first).localeCompare(getMarkdownPath(second)));
+
+export const getDocsForLocale = (entries: DocsEntry[], locale: Locale) =>
+  getPublishedDocs(entries).filter((entry) => {
+    const isLocalized = Object.keys(locales)
+      .filter((configuredLocale) => configuredLocale !== defaultLocale)
+      .some((configuredLocale) => entry.id.startsWith(`${configuredLocale}/`));
+
+    return locale === defaultLocale
+      ? !isLocalized
+      : entry.id.startsWith(`${locale}/`);
+  });

--- a/website/src/lib/llms.ts
+++ b/website/src/lib/llms.ts
@@ -38,6 +38,10 @@ export const getPageTitle = (entry: DocsEntry) =>
   entry.data.title ?? titleFromId(entry.id);
 
 export const getPageDescription = (entry: DocsEntry) => {
+  if (entry.id.endsWith('/table-of-contents.md')) {
+    return getPageTitle(entry);
+  }
+
   const description = entry.data.description ?? firstParagraph(entry.body);
 
   return removeMarkdownSyntax(description);

--- a/website/src/pages/[...slug].md.ts
+++ b/website/src/pages/[...slug].md.ts
@@ -1,18 +1,23 @@
 import { getCollection } from 'astro:content';
 import type { APIRoute } from 'astro';
-import { getMarkdownPath, getPublishedDocs, utf8Bom } from '../lib/llms';
+import {
+  getMarkdownPath,
+  getPageTitle,
+  getPublishedDocs,
+  utf8Bom,
+} from '../lib/llms';
 
 export async function getStaticPaths() {
   const entries = getPublishedDocs(await getCollection('docs'));
 
   return entries.map((entry) => ({
     params: { slug: getMarkdownPath(entry).slice(1, -3) },
-    props: { body: entry.body },
+    props: { content: `# ${getPageTitle(entry)}\n\n${entry.body}` },
   }));
 }
 
 export const GET: APIRoute = ({ props }) =>
-  new Response(`${utf8Bom}${props.body}`, {
+  new Response(`${utf8Bom}${props.content}`, {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
     },

--- a/website/src/pages/[...slug].md.ts
+++ b/website/src/pages/[...slug].md.ts
@@ -1,6 +1,6 @@
 import { getCollection } from 'astro:content';
 import type { APIRoute } from 'astro';
-import { getMarkdownPath, getPublishedDocs } from '../lib/llms';
+import { getMarkdownPath, getPublishedDocs, utf8Bom } from '../lib/llms';
 
 export async function getStaticPaths() {
   const entries = getPublishedDocs(await getCollection('docs'));
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
 }
 
 export const GET: APIRoute = ({ props }) =>
-  new Response(props.body, {
+  new Response(`${utf8Bom}${props.body}`, {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
     },

--- a/website/src/pages/[...slug].md.ts
+++ b/website/src/pages/[...slug].md.ts
@@ -1,0 +1,19 @@
+import { getCollection } from 'astro:content';
+import type { APIRoute } from 'astro';
+import { getMarkdownPath, getPublishedDocs } from '../lib/llms';
+
+export async function getStaticPaths() {
+  const entries = getPublishedDocs(await getCollection('docs'));
+
+  return entries.map((entry) => ({
+    params: { slug: getMarkdownPath(entry).slice(1, -3) },
+    props: { body: entry.body },
+  }));
+}
+
+export const GET: APIRoute = ({ props }) =>
+  new Response(props.body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });

--- a/website/src/pages/[locale]/llms.txt.ts
+++ b/website/src/pages/[locale]/llms.txt.ts
@@ -1,0 +1,39 @@
+import { getCollection } from 'astro:content';
+import type { APIRoute } from 'astro';
+import { defaultLocale, locales, type Locale } from '../../config/locales';
+import {
+  getDocsForLocale,
+  getMarkdownUrl,
+  getPageDescription,
+  getPageTitle,
+  utf8Bom,
+} from '../../lib/llms';
+
+export async function getStaticPaths() {
+  const docs = await getCollection('docs');
+
+  return Object.keys(locales)
+    .filter((locale) => locale !== defaultLocale)
+    .map((locale) => ({
+      params: { locale },
+      props: { entries: getDocsForLocale(docs, locale as Locale) },
+    }));
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const entries = props.entries as Awaited<ReturnType<typeof getCollection<'docs'>>>;
+  const homePage = entries.find((entry) => entry.id.endsWith('/index.mdx'));
+  if (!homePage) {
+    throw new Error('The localized documentation home page is required to generate llms.txt.');
+  }
+
+  const pages = entries
+    .map((entry) => `- [${getPageTitle(entry)}](${getMarkdownUrl(entry)}): ${getPageDescription(entry)}`)
+    .join('\n');
+
+  return new Response(`${utf8Bom}# ${getPageTitle(homePage)}\n\n> ${getPageDescription(homePage)}\n\n## Documentation\n\n${pages}\n`, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,0 +1,32 @@
+import { getCollection } from 'astro:content';
+import type { APIRoute } from 'astro';
+import {
+  getMarkdownUrl,
+  getPageDescription,
+  getPageTitle,
+  getPublishedDocs,
+} from '../lib/llms';
+
+export const GET: APIRoute = async () => {
+  const entries = getPublishedDocs(await getCollection('docs'));
+  const homePage = entries.find((entry) => entry.id === 'index.mdx');
+  if (!homePage) {
+    throw new Error('The root documentation page is required to generate llms.txt.');
+  }
+
+  const summary = getPageDescription(homePage);
+  const pages = entries
+    .map((entry) => {
+      const title = getPageTitle(entry);
+      const description = getPageDescription(entry);
+
+      return `- [${title}](${getMarkdownUrl(entry)}): ${description}`;
+    })
+    .join('\n');
+
+  return new Response(`# ${getPageTitle(homePage)}\n\n> ${summary}\n\n## Documentation\n\n${pages}\n`, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,14 +1,15 @@
 import { getCollection } from 'astro:content';
 import type { APIRoute } from 'astro';
 import {
+  getDocsForLocale,
   getMarkdownUrl,
   getPageDescription,
   getPageTitle,
-  getPublishedDocs,
+  utf8Bom,
 } from '../lib/llms';
 
 export const GET: APIRoute = async () => {
-  const entries = getPublishedDocs(await getCollection('docs'));
+  const entries = getDocsForLocale(await getCollection('docs'), 'root');
   const homePage = entries.find((entry) => entry.id === 'index.mdx');
   if (!homePage) {
     throw new Error('The root documentation page is required to generate llms.txt.');
@@ -24,7 +25,7 @@ export const GET: APIRoute = async () => {
     })
     .join('\n');
 
-  return new Response(`# ${getPageTitle(homePage)}\n\n> ${summary}\n\n## Documentation\n\n${pages}\n`, {
+  return new Response(`${utf8Bom}# ${getPageTitle(homePage)}\n\n> ${summary}\n\n## Documentation\n\n${pages}\n`, {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
     },


### PR DESCRIPTION
## Summary

- Generates `llms.txt` from the Astro/Starlight documentation collection, including each page title, a content-derived description, and its Markdown URL.
- Generates a clean Markdown endpoint for every documentation page, including its localized page title as an H1, for example `/book/type-annotations/index.md`.
- Uses the Astro locale configuration as the single source of truth for both Starlight and LLM output.
- Generates a root English index at `/llms.txt` plus a localized index for every configured non-default locale, for example `/bg-bg/llms.txt`.
- Prefixes generated Markdown and llms files with a UTF-8 BOM, so GitHub Pages and other static hosts decode non-Latin content correctly even when their response charset handling is incomplete.
- Uses the existing localized page title as the description for table-of-contents entries, avoiding a long list of links in the index.
- Adds focused Playwright coverage for the root index, a representative Markdown endpoint title, Bulgarian Unicode output, Chinese Unicode output, and the table-of-contents description.

## Verification

- `astro check` passed: 0 errors and 0 warnings.
- Playwright discovered all endpoint tests (7 tests total in the suite).
- The full static build could not complete in this environment because Node/Pagefind exhausted available memory while building static entrypoints.
- The browser tests could not be executed locally because the Playwright Chromium download is truncated in this environment; these environment limitations are unrelated to the change.