### PR TITLE
Automate guarded website deployment after merge

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,57 +29,7 @@ jobs:
         id: verify
         uses: actions/github-script@v8
         with:
-          script: |
-            const pullRequest = context.payload.pull_request;
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            });
-            const websiteChanged = files.some(({ filename }) => filename.startsWith('website/'));
-
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            });
-            const latestReviewByUser = new Map();
-            for (const review of reviews
-              .filter(({ user, submitted_at }) => user && submitted_at)
-              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))) {
-              latestReviewByUser.set(review.user.login, review.state);
-            }
-            const approved = [...latestReviewByUser.values()].includes('APPROVED');
-
-            const latestRun = async (workflowId) => {
-              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: workflowId,
-                event: 'pull_request',
-                head_sha: pullRequest.head.sha,
-                per_page: 100,
-              });
-              return runs.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
-            };
-            const latestValidationRun = await latestRun('validate-content.yml');
-            const validationPassed = latestValidationRun?.status === 'completed' &&
-              latestValidationRun.conclusion === 'success';
-
-            const latestE2ERun = await latestRun('website-e2e.yml');
-            const e2ePassed = latestE2ERun?.status === 'completed' &&
-              latestE2ERun.conclusion === 'success';
-
-            core.info(`Website changed: ${websiteChanged}`);
-            core.info(`Pull request approved: ${approved}`);
-            core.info(`Latest content validation run passed: ${validationPassed}`);
-            core.info(`Latest website E2E run passed: ${e2ePassed}`);
-            core.setOutput('website_changed', websiteChanged);
-            core.setOutput('approved', approved);
-            core.setOutput('validation_passed', validationPassed);
-            core.setOutput('e2e_passed', e2ePassed);
+          script: await require('./tools/github-actions/verify-website-deployment-conditions.js')({ github, context, core });
 
   deploy:
     needs: verify-deployment-conditions

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,102 @@
+name: deploy-website
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'website/**'
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: website-deploy
+  cancel-in-progress: false
+
+jobs:
+  verify-deployment-conditions:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      website_changed: ${{ steps.verify.outputs.website_changed }}
+      approved: ${{ steps.verify.outputs.approved }}
+      e2e_passed: ${{ steps.verify.outputs.e2e_passed }}
+    steps:
+      - name: Verify merged pull request conditions
+        id: verify
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+            const websiteChanged = files.some(({ filename }) => filename.startsWith('website/'));
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+            const latestReviewByUser = new Map();
+            for (const review of reviews
+              .filter(({ user, submitted_at }) => user && submitted_at)
+              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))) {
+              latestReviewByUser.set(review.user.login, review.state);
+            }
+            const approved = [...latestReviewByUser.values()].includes('APPROVED');
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'website-e2e.yml',
+              event: 'pull_request',
+              head_sha: pullRequest.head.sha,
+              per_page: 100,
+            });
+            const latestE2ERun = runs.sort(
+              (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
+            )[0];
+            const e2ePassed = latestE2ERun?.status === 'completed' &&
+              latestE2ERun.conclusion === 'success';
+
+            core.info(`Website changed: ${websiteChanged}`);
+            core.info(`Pull request approved: ${approved}`);
+            core.info(`Latest website E2E run passed: ${e2ePassed}`);
+            core.setOutput('website_changed', websiteChanged);
+            core.setOutput('approved', approved);
+            core.setOutput('e2e_passed', e2ePassed);
+
+  deploy:
+    needs: verify-deployment-conditions
+    if: >-
+      needs.verify-deployment-conditions.outputs.website_changed == 'true' &&
+      needs.verify-deployment-conditions.outputs.approved == 'true' &&
+      needs.verify-deployment-conditions.outputs.e2e_passed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install website dependencies
+        working-directory: website
+        run: npm ci
+      - name: Deploy website
+        working-directory: tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          make website-deploy

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       website_changed: ${{ steps.verify.outputs.website_changed }}
       approved: ${{ steps.verify.outputs.approved }}
+      validation_passed: ${{ steps.verify.outputs.validation_passed }}
       e2e_passed: ${{ steps.verify.outputs.e2e_passed }}
     steps:
       - name: Verify merged pull request conditions
@@ -52,25 +53,32 @@ jobs:
             }
             const approved = [...latestReviewByUser.values()].includes('APPROVED');
 
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'website-e2e.yml',
-              event: 'pull_request',
-              head_sha: pullRequest.head.sha,
-              per_page: 100,
-            });
-            const latestE2ERun = runs.sort(
-              (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
-            )[0];
+            const latestRun = async (workflowId) => {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflowId,
+                event: 'pull_request',
+                head_sha: pullRequest.head.sha,
+                per_page: 100,
+              });
+              return runs.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
+            };
+            const latestValidationRun = await latestRun('validate-content.yml');
+            const validationPassed = latestValidationRun?.status === 'completed' &&
+              latestValidationRun.conclusion === 'success';
+
+            const latestE2ERun = await latestRun('website-e2e.yml');
             const e2ePassed = latestE2ERun?.status === 'completed' &&
               latestE2ERun.conclusion === 'success';
 
             core.info(`Website changed: ${websiteChanged}`);
             core.info(`Pull request approved: ${approved}`);
+            core.info(`Latest content validation run passed: ${validationPassed}`);
             core.info(`Latest website E2E run passed: ${e2ePassed}`);
             core.setOutput('website_changed', websiteChanged);
             core.setOutput('approved', approved);
+            core.setOutput('validation_passed', validationPassed);
             core.setOutput('e2e_passed', e2ePassed);
 
   deploy:
@@ -78,6 +86,7 @@ jobs:
     if: >-
       needs.verify-deployment-conditions.outputs.website_changed == 'true' &&
       needs.verify-deployment-conditions.outputs.approved == 'true' &&
+      needs.verify-deployment-conditions.outputs.validation_passed == 'true' &&
       needs.verify-deployment-conditions.outputs.e2e_passed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/tools/github-actions/verify-website-deployment-conditions.js
+++ b/tools/github-actions/verify-website-deployment-conditions.js
@@ -1,0 +1,52 @@
+module.exports = async ({ github, context, core }) => {
+  const pullRequest = context.payload.pull_request;
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pullRequest.number,
+    per_page: 100,
+  });
+  const websiteChanged = files.some(({ filename }) => filename.startsWith('website/'));
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pullRequest.number,
+    per_page: 100,
+  });
+  const latestReviewByUser = new Map();
+  for (const review of reviews
+    .filter(({ user, submitted_at }) => user && submitted_at)
+    .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))) {
+    latestReviewByUser.set(review.user.login, review.state);
+  }
+  const approved = [...latestReviewByUser.values()].includes('APPROVED');
+
+  const latestRun = async (workflowId) => {
+    const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      workflow_id: workflowId,
+      event: 'pull_request',
+      head_sha: pullRequest.head.sha,
+      per_page: 100,
+    });
+    return runs.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
+  };
+  const latestValidationRun = await latestRun('validate-content.yml');
+  const validationPassed = latestValidationRun?.status === 'completed' &&
+    latestValidationRun.conclusion === 'success';
+
+  const latestE2ERun = await latestRun('website-e2e.yml');
+  const e2ePassed = latestE2ERun?.status === 'completed' &&
+    latestE2ERun.conclusion === 'success';
+
+  core.info(`Website changed: ${websiteChanged}`);
+  core.info(`Pull request approved: ${approved}`);
+  core.info(`Latest content validation run passed: ${validationPassed}`);
+  core.info(`Latest website E2E run passed: ${e2ePassed}`);
+  core.setOutput('website_changed', websiteChanged);
+  core.setOutput('approved', approved);
+  core.setOutput('validation_passed', validationPassed);
+  core.setOutput('e2e_passed', e2ePassed);
+};


### PR DESCRIPTION
## What changed

Adds a guarded GitHub Actions workflow that publishes the website with `make website-deploy` after an eligible pull request is merged.

The deployment workflow:

- is triggered only for closed pull requests that change `website/**`;
- proceeds only for merged pull requests;
- rechecks that the pull request changed website files and has a current approval;
- requires successful `validate-content` and `website-e2e` workflow runs for the pull request's exact head commit;
- runs the verification logic from `tools/github-actions/verify-website-deployment-conditions.js`, keeping the workflow concise and the checks independently testable;
- installs the locked website dependencies and deploys using the repository's GitHub token;
- serializes deployments to prevent concurrent `gh-pages` publishes.

## Validation

- Checked the extracted script with `node --check`.
- Ran mocked success and failure cases for the deployment conditions.
- Parsed the workflow YAML and confirmed it calls the extracted script.
- Ran `git diff --check`.
- Ran `npm run build` in `website/` successfully (0 errors, 0 warnings).
- Local Playwright execution could not complete because this sandbox cannot install Chromium; the workflow uses the repository's existing `npx playwright install --with-deps chromium` CI step.