### PR TITLE
Fix guarded website deployment workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,49 +1,28 @@
 name: deploy-website
 
 on:
-  pull_request:
-    types: [closed]
-    paths:
-      - 'website/**'
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref containing the merged website changes
+        required: true
+        type: string
 
 permissions:
-  actions: read
   contents: write
-  pull-requests: read
 
 concurrency:
   group: website-deploy
   cancel-in-progress: false
 
 jobs:
-  verify-deployment-conditions:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    outputs:
-      website_changed: ${{ steps.verify.outputs.website_changed }}
-      approved: ${{ steps.verify.outputs.approved }}
-      validation_passed: ${{ steps.verify.outputs.validation_passed }}
-      e2e_passed: ${{ steps.verify.outputs.e2e_passed }}
-    steps:
-      - name: Verify merged pull request conditions
-        id: verify
-        uses: actions/github-script@v8
-        with:
-          script: await require('./tools/github-actions/verify-website-deployment-conditions.js')({ github, context, core });
-
   deploy:
-    needs: verify-deployment-conditions
-    if: >-
-      needs.verify-deployment-conditions.outputs.website_changed == 'true' &&
-      needs.verify-deployment-conditions.outputs.approved == 'true' &&
-      needs.verify-deployment-conditions.outputs.validation_passed == 'true' &&
-      needs.verify-deployment-conditions.outputs.e2e_passed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/trigger-website-deployment.yml
+++ b/.github/workflows/trigger-website-deployment.yml
@@ -1,0 +1,37 @@
+name: trigger-website-deployment
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'website/**'
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: read
+
+jobs:
+  verify-deployment-conditions:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      ready: ${{ steps.verify.outputs.ready }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Verify merged pull request conditions
+        id: verify
+        uses: actions/github-script@v8
+        with:
+          script: await require('./tools/github-actions/verify-website-deployment-conditions.js')({ github, context, core });
+
+  deploy:
+    needs: verify-deployment-conditions
+    if: needs.verify-deployment-conditions.outputs.ready == 'true'
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      ref: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -14,5 +14,9 @@ jobs:
       - uses: actions/checkout@v7
       - name: Run compile script
         run: bash ${GITHUB_WORKSPACE}/.github/workflows/compile.sh
-
-      
+  test-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test GitHub Actions scripts
+        run: node --test tools/github-actions/*.test.js

--- a/tools/github-actions/verify-website-deployment-conditions.js
+++ b/tools/github-actions/verify-website-deployment-conditions.js
@@ -1,4 +1,12 @@
-module.exports = async ({ github, context, core }) => {
+module.exports = async ({
+  github,
+  context,
+  core,
+  maxPollAttempts = 90,
+  pollIntervalMs = 10000,
+  sleep = milliseconds =>
+    new Promise(resolve => setTimeout(resolve, milliseconds)),
+}) => {
   const pullRequest = context.payload.pull_request;
   const files = await github.paginate(github.rest.pulls.listFiles, {
     owner: context.repo.owner,
@@ -22,7 +30,7 @@ module.exports = async ({ github, context, core }) => {
   }
   const approved = [...latestReviewByUser.values()].includes('APPROVED');
 
-  const latestRun = async (workflowId) => {
+  const latestRunStartedBeforeMerge = async (workflowId) => {
     const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
       owner: context.repo.owner,
       repo: context.repo.repo,
@@ -31,22 +39,47 @@ module.exports = async ({ github, context, core }) => {
       head_sha: pullRequest.head.sha,
       per_page: 100,
     });
-    return runs.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
+    const mergedAt = new Date(pullRequest.merged_at);
+    return runs
+      .filter(
+        ({ run_started_at, created_at }) =>
+          new Date(run_started_at ?? created_at) < mergedAt,
+      )
+      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
   };
-  const latestValidationRun = await latestRun('validate-content.yml');
-  const validationPassed = latestValidationRun?.status === 'completed' &&
-    latestValidationRun.conclusion === 'success';
+  let latestValidationRun;
+  let latestE2ERun;
+  for (let attempt = 1; attempt <= maxPollAttempts; attempt += 1) {
+    [latestValidationRun, latestE2ERun] = await Promise.all([
+      latestRunStartedBeforeMerge('validate-content.yml'),
+      latestRunStartedBeforeMerge('website-e2e.yml'),
+    ]);
+    const runs = [latestValidationRun, latestE2ERun];
+    const failed = runs.some(
+      run => run?.status === 'completed' && run.conclusion !== 'success',
+    );
+    const completed = runs.every(run => run?.status === 'completed');
+    if (failed || completed || attempt === maxPollAttempts) {
+      break;
+    }
+    core.info(
+      `Waiting for prerequisite workflows (${attempt}/${maxPollAttempts})`,
+    );
+    await sleep(pollIntervalMs);
+  }
 
-  const latestE2ERun = await latestRun('website-e2e.yml');
-  const e2ePassed = latestE2ERun?.status === 'completed' &&
-    latestE2ERun.conclusion === 'success';
+  const runPassed = run =>
+    run?.status === 'completed' && run.conclusion === 'success';
+  const validationPassed = runPassed(latestValidationRun);
+  const e2ePassed = runPassed(latestE2ERun);
+  const ready = websiteChanged && approved && validationPassed && e2ePassed;
 
   core.info(`Website changed: ${websiteChanged}`);
   core.info(`Pull request approved: ${approved}`);
-  core.info(`Latest content validation run passed: ${validationPassed}`);
-  core.info(`Latest website E2E run passed: ${e2ePassed}`);
-  core.setOutput('website_changed', websiteChanged);
-  core.setOutput('approved', approved);
-  core.setOutput('validation_passed', validationPassed);
-  core.setOutput('e2e_passed', e2ePassed);
+  core.info(
+    `Latest pre-merge content validation run passed: ${validationPassed}`,
+  );
+  core.info(`Latest pre-merge website E2E run passed: ${e2ePassed}`);
+  core.info(`Website deployment ready: ${ready}`);
+  core.setOutput('ready', ready);
 };

--- a/tools/github-actions/verify-website-deployment-conditions.test.js
+++ b/tools/github-actions/verify-website-deployment-conditions.test.js
@@ -1,0 +1,140 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const verifyDeploymentConditions = require(
+  './verify-website-deployment-conditions.js',
+);
+
+const successfulRun = createdAt => ({
+  status: 'completed',
+  conclusion: 'success',
+  created_at: createdAt,
+  run_started_at: createdAt,
+  updated_at: '2026-08-08T10:02:00Z',
+});
+
+const runVerification = async ({
+  validationRuns,
+  e2eRuns,
+  maxPollAttempts = 1,
+}) => {
+  const outputs = new Map();
+  const listFiles = Symbol('listFiles');
+  const listReviews = Symbol('listReviews');
+  const listWorkflowRuns = Symbol('listWorkflowRuns');
+  let validationRequest = 0;
+  let e2eRequest = 0;
+  const responseForRequest = (responses, request) =>
+    Array.isArray(responses[0])
+      ? responses[Math.min(request, responses.length - 1)]
+      : responses;
+  const github = {
+    paginate: async (method, options) => {
+      if (method === listFiles) {
+        return [{ filename: 'website/src/content.md' }];
+      }
+      if (method === listReviews) {
+        return [
+          {
+            user: { login: 'reviewer' },
+            submitted_at: '2026-08-08T09:50:00Z',
+            state: 'APPROVED',
+          },
+        ];
+      }
+      if (options.workflow_id === 'validate-content.yml') {
+        return responseForRequest(validationRuns, validationRequest++);
+      }
+      if (options.workflow_id === 'website-e2e.yml') {
+        return responseForRequest(e2eRuns, e2eRequest++);
+      }
+      throw new Error(`Unexpected pagination request for ${String(method)}`);
+    },
+    rest: {
+      pulls: { listFiles, listReviews },
+      actions: { listWorkflowRuns },
+    },
+  };
+
+  await verifyDeploymentConditions({
+    github,
+    context: {
+      payload: {
+        pull_request: {
+          number: 123,
+          head: { sha: 'abc123' },
+          merged_at: '2026-08-08T10:00:00Z',
+        },
+      },
+      repo: { owner: 'gibbok', repo: 'typescript-book' },
+    },
+    core: {
+      info: () => {},
+      setOutput: (name, value) => outputs.set(name, value),
+    },
+    maxPollAttempts,
+    pollIntervalMs: 0,
+    sleep: async () => {},
+  });
+
+  return outputs.get('ready');
+};
+
+test('allows deployment after both prerequisite workflows passed', async () => {
+  const run = successfulRun('2026-08-08T09:55:00Z');
+  assert.equal(
+    await runVerification({ validationRuns: [run], e2eRuns: [run] }),
+    true,
+  );
+});
+
+test('rejects a successful cleanup run that started after the merge', async () => {
+  const failedTestRun = {
+    ...successfulRun('2026-08-08T09:55:00Z'),
+    conclusion: 'failure',
+  };
+  const successfulCleanupRun = successfulRun('2026-08-08T10:00:00Z');
+  assert.equal(
+    await runVerification({
+      validationRuns: [successfulRun('2026-08-08T09:55:00Z')],
+      e2eRuns: [successfulCleanupRun, failedTestRun],
+    }),
+    false,
+  );
+});
+
+test('rejects a prerequisite workflow that remains in progress', async () => {
+  const inProgressRun = {
+    ...successfulRun('2026-08-08T09:58:00Z'),
+    status: 'in_progress',
+    conclusion: null,
+  };
+  assert.equal(
+    await runVerification({
+      validationRuns: [successfulRun('2026-08-08T09:55:00Z')],
+      e2eRuns: [inProgressRun],
+    }),
+    false,
+  );
+});
+
+test('waits for a pre-merge workflow run to finish successfully', async () => {
+  const inProgressRun = {
+    ...successfulRun('2026-08-08T09:58:00Z'),
+    status: 'in_progress',
+    conclusion: null,
+  };
+  const completedRun = {
+    ...inProgressRun,
+    status: 'completed',
+    conclusion: 'success',
+  };
+  assert.equal(
+    await runVerification({
+      validationRuns: [successfulRun('2026-08-08T09:55:00Z')],
+      e2eRuns: [[inProgressRun], [completedRun]],
+      maxPollAttempts: 2,
+    }),
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the website deployment failure and makes deployment start only after its prerequisite workflows are confirmed green.

## Root cause

The verification job loaded `tools/github-actions/verify-website-deployment-conditions.js` before checking out the repository, so the file did not exist on the runner.

## What changed

- Adds a merge-triggered deployment gate that checks out the merged base branch before loading the verification script.
- Converts `deploy-website.yml` into a reusable workflow. It is called only when the gate reports that:
  - the merged PR changed `website/**`;
  - the PR has a valid approval;
  - the latest `validate-content.yml` run for the exact PR head SHA completed successfully;
  - the latest genuine `website-e2e.yml` run for the exact PR head SHA completed successfully.
- Waits for prerequisite runs that started before merge but are still finishing.
- Excludes the merge-time E2E artifact-cleanup run, which can be green without running E2E tests.
- Adds focused unit tests and runs them from `validate-content.yml`.

## Validation

- `node --test tools/github-actions/verify-website-deployment-conditions.test.js` — 4 tests passed.
- JavaScript syntax checks passed for the verification script and its tests.
- YAML parsing passed for all changed workflows.
- Structural checks confirmed checkout occurs before the local script is required and the reusable deployment workflow is reachable only through the successful gate.
- `git diff --check` passed.
- Verified against PR #214 workflow data: the real validation and E2E runs are selected, while the later cleanup-only E2E run is ignored.