### PR TITLE
Configure Git identity for website deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -38,5 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           make website-deploy


### PR DESCRIPTION
## Summary

Configure the standard GitHub Actions bot identity before running the website deployment.

## Root cause

The `gh-pages` deployment creates a Git commit for the generated website. GitHub Actions runners do not have an author name or email configured by default, so the deployment failed with `ProcessError: Author identity unknown`.

## Impact

The existing automatic deployment after a merged website PR and the manual deployment trigger remain unchanged. The deployment commit can now be created non-interactively by the workflow.

## Validation

- Confirmed the branch is based on the current `main` and contains only two added workflow lines.
- Ran the repository's exact `gh-pages@6.1.1` publishing mechanism against an isolated local Git remote.
- Confirmed publication succeeded and the generated commit used `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
- Did not run the live deployment, avoiding an unintended website publication during validation.
