### PR TITLE
Trigger website E2E on new website pull requests

### DIFF
--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -2,7 +2,9 @@ name: website-e2e
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize, closed]
+    types: [opened, reopened, ready_for_review, synchronize, closed]
+    paths:
+      - 'website/**'
 
 permissions:
   actions: write
@@ -14,7 +16,14 @@ jobs:
   test:
     if: >-
       github.event.action == 'ready_for_review' ||
-      (github.event.action == 'synchronize' && github.event.pull_request.draft == false)
+      (
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize'
+        ) &&
+        github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:


### PR DESCRIPTION
## What changed

- Trigger `website-e2e` for `opened` and `reopened` pull request events.
- Limit the workflow to pull requests that change `website/**`.
- Keep draft pull requests from running E2E until they are marked ready for review.

## Why

PR #219 changes files under `website/`, but it was opened as a non-draft pull request. The workflow did not subscribe to the `opened` event, so GitHub created no website E2E run. Subsequent pushes would trigger `synchronize`, but the initial E2E check was missing.

## Validation

- Verified the updated workflow content on the remote branch.
- Confirmed the trigger includes `opened`, `reopened`, `ready_for_review`, `synchronize`, and `closed`.
- Confirmed the `website/**` path filter and draft guard are present.
