### PR TITLE
Run website E2E on newly opened pull requests

### DIFF
--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -2,7 +2,7 @@ name: website-e2e
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize, closed]
+    types: [opened, reopened, ready_for_review, synchronize, closed]
 
 permissions:
   actions: write
@@ -14,7 +14,10 @@ jobs:
   test:
     if: >-
       github.event.action == 'ready_for_review' ||
-      (github.event.action == 'synchronize' && github.event.pull_request.draft == false)
+      (
+        (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
+        github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:


### PR DESCRIPTION
## Summary

- trigger the website E2E workflow when a non-draft pull request is opened
- also handle reopened non-draft pull requests
- preserve the existing draft and synchronize behavior

## Root cause

The workflow listened for `ready_for_review`, `synchronize`, and `closed`, but not `opened`. Therefore, a newly opened non-draft pull request that changed the website, such as #219, did not start the E2E workflow.

## Validation

- verified the updated workflow content on the pushed branch
- verified the branch contains only the workflow change
- local test execution was not available because this workspace had no repository checkout or GitHub CLI