### PR TITLE
Add weekly TypeScript news workflow

### DIFF
--- a/.github/codex/prompts/weekly-typescript-news.md
+++ b/.github/codex/prompts/weekly-typescript-news.md
@@ -1,0 +1,66 @@
+# Weekly TypeScript news
+
+Create one new TypeScript news or educational article for this repository.
+
+For this scheduled automation only, the repository owner's instructions in this prompt authorize autonomous research and topic selection. Treat the authoritative primary source you select, including its publication date and URL, as the user-supplied source content required by `.agents/skills/create-typescript-news/SKILL.md`. Follow that skill completely after selecting the source.
+
+## Research and selection
+
+* Research one fresh TypeScript news or educational topic published during the 30 calendar days before this run.
+* Prefer authoritative primary sources, especially official TypeScript, Microsoft, TC39, GitHub, and maintainers' announcements.
+* Do not treat search-result snippets, aggregators, reposts, or AI-generated summaries as primary sources.
+* Before choosing a topic, inspect all existing TypeScript news and relevant website content in every locale configured by `website/astro.config.mjs`.
+* Reject duplicate, near-duplicate, and substantially overlapping topics, even when the title or source differs.
+* If no unique, timely, well-supported topic exists, make no file changes and finish with a brief explanation. The workflow will then exit without opening a pull request.
+
+## Article and translations
+
+* Read and follow `.agents/skills/create-typescript-news/SKILL.md` and every repository instruction it references.
+* Treat English as the canonical master article.
+* Write an accurate, concise, useful article rather than merely rewriting the source.
+* Create natural, faithful translations for every supported website language.
+* Keep facts, metadata, dates, slugs, ordering, navigation, commands, code, and technical meaning equivalent across all languages.
+* Add external source links to the published article only when the repository skill requires them.
+
+## Validation
+
+Run every validation required by the repository skill, including:
+
+* `python3 .agents/skills/create-typescript-news/scripts/verify_news_order.py`;
+* formatting and content checks applicable to the changed files;
+* full inventory and factual parity checks across every configured locale;
+* duplicate and near-duplicate review against existing website content;
+* `npm run build` from `website/`;
+* checks that ordering, routes, sitemap entries, canonical URLs, descriptions, and publication metadata are correct.
+
+Fix every issue before finishing. Do not commit, push, create a branch, or open a pull request; the workflow performs those operations in a separate job.
+
+## Final response
+
+When changes were made, return only a Markdown pull-request description with these headings and complete details:
+
+## Chosen topic
+
+State the topic and article path.
+
+## Why it is timely
+
+State the source publication date and why the topic matters now.
+
+## Duplication review
+
+Describe all existing TypeScript news and relevant website content checked across every supported language, and explain why the new article does not overlap.
+
+## Languages updated
+
+List every language updated.
+
+## Validation performed
+
+List each command and manual consistency check performed, with its result.
+
+## Original sources
+
+List the original primary source URL or URLs used for factual review.
+
+Do not claim that a check passed unless you actually ran it successfully.

--- a/.github/workflows/weekly-typescript-news.yml
+++ b/.github/workflows/weekly-typescript-news.yml
@@ -1,0 +1,109 @@
+name: Weekly TypeScript news
+
+on:
+  schedule:
+    - cron: '0 9 * * 5'
+      timezone: Europe/Prague
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-typescript-news
+  cancel-in-progress: false
+
+jobs:
+  generate-news:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      has_patch: ${{ steps.diff.outputs.has_patch }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Research and create TypeScript news
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/weekly-typescript-news.md
+          output-file: ${{ runner.temp }}/typescript-news-pr-body.md
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+          codex-args: '["--search", "--ephemeral"]'
+
+      - name: Create patch artifact
+        id: diff
+        run: |
+          git add -N .
+          git diff --binary HEAD > "${RUNNER_TEMP}/typescript-news.patch"
+          if [ -s "${RUNNER_TEMP}/typescript-news.patch" ]; then
+            test -s "${RUNNER_TEMP}/typescript-news-pr-body.md"
+            echo 'has_patch=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_patch=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload generated changes
+        if: steps.diff.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: weekly-typescript-news-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/typescript-news.patch
+            ${{ runner.temp }}/typescript-news-pr-body.md
+          if-no-files-found: error
+          retention-days: 7
+
+  open-draft-pr:
+    needs: generate-news
+    if: needs.generate-news.outputs.has_patch == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: weekly-typescript-news-${{ github.run_id }}
+          path: ${{ runner.temp }}/weekly-typescript-news
+
+      - name: Commit changes and open draft pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          artifact_dir="${RUNNER_TEMP}/weekly-typescript-news"
+          branch="automation/typescript-news-${RUN_ID}"
+
+          git apply --index "${artifact_dir}/typescript-news.patch"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "$branch"
+          git commit -m 'Add weekly TypeScript news'
+          git push origin "$branch"
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title 'Add weekly TypeScript news' \
+            --body-file "${artifact_dir}/typescript-news-pr-body.md" \
+            --draft


### PR DESCRIPTION
## What changed

* Added a dedicated weekly GitHub Actions workflow for TypeScript news.
* Scheduled it for every Friday at 09:00 in `Europe/Prague`, with a manual `workflow_dispatch` trigger.
* Added a reusable Codex prompt that requires current primary-source research, full duplicate review, every configured translation, repository-skill compliance, and all required validations.
* The workflow makes no commit and opens no pull request when no unique, high-quality topic is available.
* When changes exist, it creates a unique automation branch and opens a draft pull request containing the topic, timeliness, duplication review, languages, validations, and source URLs.

## Security and permissions

The workflow follows the documented two-job Codex pattern:

* the Codex job has read-only repository permission and no persisted GitHub credentials;
* generated changes are transferred as a patch artifact;
* a separate job without the OpenAI API key receives write permission, commits the patch, pushes the branch, and opens the draft pull request.

## Configuration required

Add an Actions repository secret named `OPENAI_API_KEY` before running the workflow.

The repository must also allow GitHub Actions to create pull requests.

## Validation

* Parsed the workflow successfully as YAML.
* Verified job outputs and conditional handoff use valid identifiers.
* Verified read/write permissions are isolated between jobs.
* Verified checkout credentials are not persisted in the Codex job.
* Verified the generated pull request is created with `--draft`.
* Compared both files on the remote branch with the validated local versions.