### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/website"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/website"

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.event.pull_request.base.ref }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: website
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -41,7 +41,7 @@ jobs:
       - name: Upload Playwright evidence
         if: always()
         id: evidence
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-evidence-pr-${{ github.event.pull_request.number }}
           path: |
@@ -51,7 +51,7 @@ jobs:
           retention-days: 14
       - name: Add evidence to pull request
         if: always() && steps.evidence.outputs.artifact-url != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           ARTIFACT_URL: ${{ steps.evidence.outputs.artifact-url }}
           TEST_STATUS: ${{ job.status }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete merged pull request evidence
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const artifactName = `playwright-evidence-pr-${context.issue.number}`;


### PR DESCRIPTION
## Summary

- Update repository-controlled GitHub Actions to current Node 24-compatible major versions:
  - `actions/setup-node@v7`
  - `actions/upload-artifact@v7`
  - `actions/github-script@v9`
- Keep the existing `actions/checkout@v7` usage.
- Preserve the current website deployment flow and permissions.

## Validation

- Repository validation workflow [run 519](https://github.com/gibbok/typescript-book/actions/runs/33107380561) passed all four jobs.
- Website E2E was skipped because this pull request is intentionally draft.

The referenced warning was reproduced from the GitHub-managed Pages workflow. That run uses `actions/upload-pages-artifact@v3`, which internally invokes `actions/upload-artifact@v4`. This workflow is not stored in the repository and cannot be changed by this PR.

This PR updates all repository-controlled action references. The managed Pages warning will require GitHub to update its generated workflow or a separate migration from branch-based Pages deployment to the Pages Actions deployment model.