### PR TITLE
test: add E2E coverage for all website locales

### DIFF
--- a/website/e2e/bulgarian.spec.ts
+++ b/website/e2e/bulgarian.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Bulgarian reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'bg-bg/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'bg-BG');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Първи стъпки с TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code предоставя отлична поддръжка за езика TypeScript',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('bg-bg/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('За автора');
+    await expect(page.locator('body')).toContainText(
+      '/bg-bg/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/chinese.spec.ts
+++ b/website/e2e/chinese.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Chinese reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'zh-cn/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'TypeScript 入门',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code 为 TypeScript 语言提供了出色的支持',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('zh-cn/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('关于作者');
+    await expect(page.locator('body')).toContainText(
+      '/zh-cn/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/english.spec.ts
+++ b/website/e2e/english.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('English reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Getting Started With TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code provides excellent support for the TypeScript language',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('About the Author');
+    await expect(page.locator('body')).toContainText(
+      '/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/italian.spec.ts
+++ b/website/e2e/italian.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Italian reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'it-it/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'it-IT');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Per iniziare con TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code offre un eccellente supporto per il linguaggio TypeScript',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('it-it/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText(
+      "Informazioni sull'autore",
+    );
+    await expect(page.locator('body')).toContainText(
+      '/it-it/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/portuguese.spec.ts
+++ b/website/e2e/portuguese.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Portuguese reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'pt-br/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Começando com TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'O Visual Studio Code oferece excelente suporte para a linguagem TypeScript',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('pt-br/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('Sobre o Autor');
+    await expect(page.locator('body')).toContainText(
+      '/pt-br/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/spanish.spec.ts
+++ b/website/e2e/spanish.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Spanish reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'es-es/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'es-ES');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Primeros pasos con TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code ofrece una excelente compatibilidad con el lenguaje TypeScript',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('es-es/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('Sobre el autor');
+    await expect(page.locator('body')).toContainText(
+      '/es-es/book/about-the-author/index.md',
+    );
+  });
+});

--- a/website/e2e/swedish.spec.ts
+++ b/website/e2e/swedish.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Swedish reader', () => {
+  test('renders the localized book page', async ({ page }) => {
+    const response = await page.goto(
+      'sv-se/book/getting-started-with-typescript/',
+    );
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'sv-SE');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Komma igång med TypeScript',
+      }),
+    ).toBeVisible();
+
+    await expect(page.locator('main[data-pagefind-body]')).toContainText(
+      'Visual Studio Code erbjuder utmärkt stöd för TypeScript-språket',
+    );
+  });
+
+  test('exposes the localized documentation index', async ({ page }) => {
+    const response = await page.goto('sv-se/llms.txt');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('body')).toContainText('Om författaren');
+    await expect(page.locator('body')).toContainText(
+      '/sv-se/book/about-the-author/index.md',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add locale-specific reader E2E specs for English, Chinese, Italian, Portuguese, Swedish, Bulgarian, and Spanish.
- Keep each spec aligned with the existing Japanese template.
- Cover the localized book page and locale-specific `llms.txt` index.

## Scope

Only files under `website/e2e/` are changed.

## Validation

- `npm run build` passes with zero Astro diagnostics.
- `npx playwright test --list` discovers all 23 tests.
- Two independent route/content/template checks pass for all seven new specs.