### PR TITLE
Preserve Polish translation source fidelity

### DIFF
--- a/README-pl_PL.md
+++ b/README-pl_PL.md
@@ -1218,7 +1218,7 @@ Warto zauważyć, że podczas używania asercji typu TypeScript nie przeprowadza
 
 #### Deklaracje otoczenia
 
-Deklaracje otoczenia to pliki opisujące typy kodu JavaScript; ich nazwy mają format `.d.ts`. Zazwyczaj są importowane i używane do opisywania typami istniejących bibliotek JavaScript lub do dodawania typów do istniejących plików JS w projekcie.
+Deklaracje otoczenia to pliki opisujące typy kodu JavaScript; ich nazwy mają format `.d.ts.`. Zazwyczaj są importowane i używane do opisywania typami istniejących bibliotek JavaScript lub do dodawania typów do istniejących plików JS w projekcie.
 
 Typy dla wielu popularnych bibliotek można znaleźć pod adresem:
 [https://github.com/DefinitelyTyped/DefinitelyTyped/](https://github.com/DefinitelyTyped/DefinitelyTyped/)
@@ -2699,7 +2699,7 @@ type TypeName = {
 ```
 
 `interface InterfaceName` lub `type TypeName`: definiuje nazwę interfejsu lub typu.
-`property1: Type1`: określa właściwości interfejsu wraz z odpowiadającymi im typami. Można zdefiniować wiele właściwości, oddzielając każdą z nich średnikiem.
+`property1`: `Type1`: określa właściwości interfejsu wraz z odpowiadającymi im typami. Można zdefiniować wiele właściwości, oddzielając każdą z nich średnikiem.
 `method1(arg1: ArgType1, arg2: ArgType2): ReturnType;`: określa metody interfejsu. Metody definiuje się za pomocą ich nazw, po których następuje ujęta w nawiasy lista parametrów oraz typ zwracany. Można zdefiniować wiele metod, oddzielając każdą z nich średnikiem.
 
 Przykład interfejsu:

--- a/website/src/content/docs/pl-pl/book/exploring-the-type-system.md
+++ b/website/src/content/docs/pl-pl/book/exploring-the-type-system.md
@@ -485,7 +485,7 @@ Warto zauważyć, że podczas używania asercji typu TypeScript nie przeprowadza
 
 #### Deklaracje otoczenia
 
-Deklaracje otoczenia to pliki opisujące typy kodu JavaScript; ich nazwy mają format `.d.ts`. Zazwyczaj są importowane i używane do opisywania typami istniejących bibliotek JavaScript lub do dodawania typów do istniejących plików JS w projekcie.
+Deklaracje otoczenia to pliki opisujące typy kodu JavaScript; ich nazwy mają format `.d.ts.`. Zazwyczaj są importowane i używane do opisywania typami istniejących bibliotek JavaScript lub do dodawania typów do istniejących plików JS w projekcie.
 
 Typy dla wielu popularnych bibliotek można znaleźć pod adresem:
 [https://github.com/DefinitelyTyped/DefinitelyTyped/](https://github.com/DefinitelyTyped/DefinitelyTyped/)

--- a/website/src/content/docs/pl-pl/book/interface-and-type.md
+++ b/website/src/content/docs/pl-pl/book/interface-and-type.md
@@ -33,7 +33,7 @@ type TypeName = {
 ```
 
 `interface InterfaceName` lub `type TypeName`: definiuje nazwę interfejsu lub typu.
-`property1: Type1`: określa właściwości interfejsu wraz z odpowiadającymi im typami. Można zdefiniować wiele właściwości, oddzielając każdą z nich średnikiem.
+`property1`: `Type1`: określa właściwości interfejsu wraz z odpowiadającymi im typami. Można zdefiniować wiele właściwości, oddzielając każdą z nich średnikiem.
 `method1(arg1: ArgType1, arg2: ArgType2): ReturnType;`: określa metody interfejsu. Metody definiuje się za pomocą ich nazw, po których następuje ujęta w nawiasy lista parametrów oraz typ zwracany. Można zdefiniować wiele metod, oddzielając każdą z nich średnikiem.
 
 Przykład interfejsu:


### PR DESCRIPTION
## Summary

- audit the already-merged Polish translation against the English `README.md`
- preserve the English source token `.d.ts.` exactly instead of silently correcting it in Polish
- preserve separate inline tokens `property1` and `Type1` instead of merging them
- synchronize the two affected generated Polish website pages

## Validation

- English and Polish README line counts match: 5,186 / 5,186
- all 289 fenced code blocks are byte-identical
- all 214 heading levels match
- TOC link counts match: 214 / 214
- Polish locale remains configured as `pl_PL` / `pl-PL` / `pl-pl`
- content lint: passed
- TypeScript snippet compilation: passed
- TypeScript News locale/order verification: passed
- GitHub Actions script tests: passed
- Playwright E2E: intentionally skipped because the PR is draft
- PDF/EPUB generation: not run

The full Polish implementation and Astro production build were already completed in #236, whose final tree is the current `main` baseline. This draft PR contains only the source-fidelity corrections found during the requested fresh audit. A fresh local Astro build could not be executed in this runtime because direct repository/package network access is unavailable; no E2E run was substituted for it.